### PR TITLE
Implement weekly calendar with subject selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,13 @@ import { materiasElectivas } from "./data/materias-electivas.js";
 import MateriasSelector from "./components/MateriasSelector.jsx";
 import MateriasHabilitadas from "./components/MateriasHabilitadas.jsx";
 import MateriasElectivas from "./components/MateriasElectivas.jsx";
+import WeeklySchedule from "./components/WeeklySchedule.jsx";
 
 function puedeCursar(materia, estados, estadosElectivas) {
   // Helper para obtener el estado de cualquier materia (regular o electiva)
   const getEstado = id => {
-    if (estados.hasOwnProperty(id)) return estados[id];
-    if (estadosElectivas && estadosElectivas.hasOwnProperty(id)) return estadosElectivas[id];
+    if (Object.prototype.hasOwnProperty.call(estados, id)) return estados[id];
+    if (estadosElectivas && Object.prototype.hasOwnProperty.call(estadosElectivas, id)) return estadosElectivas[id];
     return undefined;
   };
   // Log para todas las materias
@@ -124,8 +125,8 @@ export default function App() {
   const puedeCursarElectiva = (electiva) => {
     // Las electivas pueden tener correlativas regulares o electivas
     const getEstado = id => {
-      if (estados.hasOwnProperty(id)) return estados[id];
-      if (estadosElectivas.hasOwnProperty(id)) return estadosElectivas[id];
+      if (Object.prototype.hasOwnProperty.call(estados, id)) return estados[id];
+      if (Object.prototype.hasOwnProperty.call(estadosElectivas, id)) return estadosElectivas[id];
       return undefined;
     };
     const regulares = electiva.requisitosRegular.every(id => getEstado(id) === "regular" || getEstado(id) === "aprobada");
@@ -161,6 +162,7 @@ export default function App() {
       />
       <h3>Materias que puedes cursar:</h3>
       <MateriasHabilitadas materias={materiasHabilitadas} estados={estados} />
+      <WeeklySchedule />
     </div>
   );
 }

--- a/src/components/MateriasElectivas.jsx
+++ b/src/components/MateriasElectivas.jsx
@@ -31,7 +31,7 @@ export default function MateriasElectivas({ electivas, estados, estadosMaterias,
   function puedeCursarElectiva(electiva) {
     const getEstado = id => {
       // Si el id corresponde a una electiva, busca en estados; si no, en estadosMaterias
-      if (estados.hasOwnProperty(id)) return estados[id];
+      if (Object.prototype.hasOwnProperty.call(estados, id)) return estados[id];
       return estadosMaterias[id];
     };
     const regulares = electiva.requisitosRegular.every(id => getEstado(id) === "regular" || getEstado(id) === "aprobada");
@@ -43,7 +43,7 @@ export default function MateriasElectivas({ electivas, estados, estadosMaterias,
     <Container className="mb-4">
       <h3 className="mb-3"><Badge bg="info">Créditos obtenidos: {creditosAprobados}</Badge></h3>
       <Row>
-        {niveles.map((nivel, idx) => (
+        {niveles.map(nivel => (
           <Col key={nivel} xs={12} sm={6} md={4} className="mb-3">
             <Card>
               <Card.Header className="text-center">Nivel {nivel}</Card.Header>

--- a/src/components/MateriasHabilitadas.jsx
+++ b/src/components/MateriasHabilitadas.jsx
@@ -14,7 +14,6 @@ export default function MateriasHabilitadas({ materias }) {
     const imgData = canvas.toDataURL("image/png");
     const pdf = new jsPDF({ orientation: "landscape" });
     const pageWidth = pdf.internal.pageSize.getWidth();
-    const pageHeight = pdf.internal.pageSize.getHeight();
     const imgProps = pdf.getImageProperties(imgData);
     const imgWidth = pageWidth;
     const imgHeight = (imgProps.height * imgWidth) / imgProps.width;

--- a/src/components/MateriasSelector.jsx
+++ b/src/components/MateriasSelector.jsx
@@ -26,7 +26,7 @@ export default function MateriasSelector({ materiasPorNivel, estados, estadosEle
     <Container className="mb-4">
 
       <Row>
-        {niveles.map((nivel, idx) => (
+        {niveles.map(nivel => (
           <Col key={nivel} xs={12} sm={6} md={4} className="mb-3">
             <Card>
               <Card.Header className="text-center">Nivel {nivel}</Card.Header>

--- a/src/components/WeeklySchedule.css
+++ b/src/components/WeeklySchedule.css
@@ -1,0 +1,78 @@
+.weekly-container {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.subject-list {
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.subject-btn {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  background: #f8f8f8;
+  cursor: pointer;
+}
+
+.subject-btn.active {
+  background: #40e0d0;
+  color: #fff;
+}
+
+.calendar {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 60px repeat(6, 1fr);
+  position: relative;
+}
+
+.time-column .time-cell {
+  height: var(--row-height);
+  border-bottom: 1px solid #eee;
+  font-size: 12px;
+}
+
+.day-column {
+  position: relative;
+  border-left: 1px solid #eee;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent,
+    transparent calc(var(--row-height) - 1px),
+    #eee calc(var(--row-height) - 1px),
+    #eee var(--row-height)
+  );
+}
+
+.event-block {
+  position: absolute;
+  left: 2px;
+  right: 2px;
+  background: #ffe5b4;
+  border: 2px dotted #ffa500;
+  border-radius: 4px;
+  font-size: 12px;
+  padding: 2px;
+  box-sizing: border-box;
+}
+
+.event-block.selected {
+  background: #40e0d0;
+  border: 2px solid #008b8b;
+  color: #fff;
+}
+
+.event-block.dimmed {
+  opacity: 0.3;
+}
+
+.event-block .close {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  cursor: pointer;
+}

--- a/src/components/WeeklySchedule.jsx
+++ b/src/components/WeeklySchedule.jsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import { scheduleData } from "../data/horario";
+import "./WeeklySchedule.css";
+
+const days = ["Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"];
+const startTime = 8 * 60; // 08:00
+const endTime = 13 * 60; // 13:00
+const pxPerMin = 2;
+const rowHeight = 25 * pxPerMin;
+const totalHeight = (endTime - startTime) * pxPerMin;
+
+function parseTime(time) {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+}
+
+function minutesToLabel(mins) {
+  const h = Math.floor(mins / 60);
+  const m = mins % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+export default function WeeklySchedule() {
+  const [selectedSubject, setSelectedSubject] = useState(null);
+
+  const subjectsMap = new Map();
+  scheduleData.forEach(ev => {
+    if (!subjectsMap.has(ev.codigo)) {
+      subjectsMap.set(ev.codigo, ev.materia);
+    }
+  });
+  const subjects = Array.from(subjectsMap.entries()).map(([codigo, materia]) => ({ codigo, materia }));
+
+  const times = [];
+  for (let t = startTime; t <= endTime; t += 25) {
+    times.push(t);
+  }
+
+  const handleSelect = codigo => {
+    setSelectedSubject(prev => (prev === codigo ? null : codigo));
+  };
+
+  return (
+    <div className="weekly-container">
+      <aside className="subject-list">
+        {subjects.map(sub => (
+          <button
+            key={sub.codigo}
+            className={`subject-btn ${selectedSubject === sub.codigo ? "active" : ""}`}
+            onClick={() => handleSelect(sub.codigo)}
+          >
+            {sub.codigo} - {sub.materia}
+          </button>
+        ))}
+      </aside>
+      <div className="calendar" style={{"--row-height": `${rowHeight}px`}}>
+        <div className="time-column" style={{ height: `${totalHeight}px` }}>
+          {times.map(t => (
+            <div key={t} className="time-cell">
+              {minutesToLabel(t)}
+            </div>
+          ))}
+        </div>
+        {days.map(day => (
+          <div key={day} className="day-column" style={{ height: `${totalHeight}px` }}>
+            {scheduleData.filter(ev => ev.dia === day).map((ev, idx) => {
+              const top = (parseTime(ev.inicio) - startTime) * pxPerMin;
+              const height = (parseTime(ev.fin) - parseTime(ev.inicio)) * pxPerMin;
+              const selected = selectedSubject === ev.codigo;
+              const dimmed = selectedSubject && selectedSubject !== ev.codigo;
+              return (
+                <div
+                  key={idx}
+                  className={`event-block ${selected ? "selected" : ""} ${dimmed ? "dimmed" : ""}`}
+                  style={{ top: `${top}px`, height: `${height}px` }}
+                >
+                  {ev.codigo} - {ev.grupo}
+                  {selected && (
+                    <span className="close" onClick={() => setSelectedSubject(null)}>
+                      ×
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/horario.js
+++ b/src/data/horario.js
@@ -1,0 +1,25 @@
+export const scheduleData = [
+  { dia: "Lunes", inicio: "08:00", fin: "09:30", materia: "Administración de Sistemas", codigo: "AS", grupo: "4K1" },
+  { dia: "Lunes", inicio: "09:40", fin: "10:25", materia: "Administración de Sistemas", codigo: "AS", grupo: "4K1" },
+  { dia: "Lunes", inicio: "10:25", fin: "11:10", materia: "Investigación Operativa", codigo: "IOP", grupo: "4K1" },
+  { dia: "Lunes", inicio: "11:20", fin: "12:05", materia: "Investigación Operativa", codigo: "IOP", grupo: "4K1" },
+  { dia: "Lunes", inicio: "12:05", fin: "12:50", materia: "Redes de Datos", codigo: "RED", grupo: "4K1" },
+
+  { dia: "Martes", inicio: "08:00", fin: "09:30", materia: "Redes de Datos", codigo: "RED", grupo: "4K1" },
+  { dia: "Martes", inicio: "09:40", fin: "10:25", materia: "Investigación Operativa", codigo: "IOP", grupo: "4K1" },
+  { dia: "Martes", inicio: "10:25", fin: "12:50", materia: "Electiva 1", codigo: "EL1", grupo: "4K1" },
+
+  { dia: "Miércoles", inicio: "08:00", fin: "09:30", materia: "Simulación", codigo: "SIM", grupo: "4K1" },
+  { dia: "Miércoles", inicio: "09:40", fin: "10:25", materia: "Simulación", codigo: "SIM", grupo: "4K1" },
+  { dia: "Miércoles", inicio: "10:25", fin: "12:50", materia: "Electiva 2", codigo: "EL2", grupo: "4K1" },
+
+  { dia: "Jueves", inicio: "08:00", fin: "09:30", materia: "Administración de Sistemas", codigo: "AS", grupo: "4K1" },
+  { dia: "Jueves", inicio: "09:40", fin: "10:25", materia: "Administración de Sistemas", codigo: "AS", grupo: "4K1" },
+  { dia: "Jueves", inicio: "10:25", fin: "11:10", materia: "Simulación", codigo: "SIM", grupo: "4K1" },
+  { dia: "Jueves", inicio: "11:20", fin: "12:05", materia: "Simulación", codigo: "SIM", grupo: "4K1" },
+
+  { dia: "Viernes", inicio: "08:00", fin: "09:30", materia: "Electiva 1", codigo: "EL1", grupo: "4K1" },
+  { dia: "Viernes", inicio: "09:40", fin: "10:25", materia: "Electiva 1", codigo: "EL1", grupo: "4K1" },
+  { dia: "Viernes", inicio: "10:25", fin: "11:10", materia: "Electiva 2", codigo: "EL2", grupo: "4K1" },
+  { dia: "Viernes", inicio: "11:20", fin: "12:50", materia: "Electiva 2", codigo: "EL2", grupo: "4K1" },
+];


### PR DESCRIPTION
## Summary
- add sample schedule data
- implement WeeklySchedule component rendering weekly grid with selectable subjects
- connect WeeklySchedule into App and fix lint issues

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f1fba9388328868048b51749e482